### PR TITLE
Misc updates

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -5,15 +5,15 @@ silent: true
 
 vars:
   SPECS_TEMPLATE_NAME: laravel-13-project
-  SPECS_TEMPLATE_TEST_NAME: "{{.SPECS_TEMPLATE_NAME}}-test"
+  SPECS_TEMPLATE_TEST_NAME: '{{ .SPECS_TEMPLATE_NAME }}-test'
 
 tasks:
 
   update:
     desc: Update the specs template
-    deps: [cleanup:ignored]
+    deps: [ cleanup:ignored ]
     cmds:
-      - specs template save . "{{.SPECS_TEMPLATE_NAME}}" --force
+      - specs template save . "{{ .SPECS_TEMPLATE_NAME }}" --force
 
   cleanup:ignored:
     desc: Remove all git ignored files
@@ -34,37 +34,37 @@ tasks:
 
   test:
     desc: Test the specs template
-    deps: [cleanup:ignored, test:cleanup]
+    deps: [ cleanup:ignored, test:cleanup ]
     cmds:
-      - specs template save . "{{.SPECS_TEMPLATE_TEST_NAME}}" --force
-      - specs template use "{{.SPECS_TEMPLATE_TEST_NAME}}" "../{{.SPECS_TEMPLATE_TEST_NAME}}" --use-defaults
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" commit -m "Initial commit"
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" remote add origin git@github.com:specsnl/laravel-project-test.git
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" fetch
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" branch --set-upstream-to=origin/main main
-      - code "../{{.SPECS_TEMPLATE_TEST_NAME}}"
+      - specs template save . "{{ .SPECS_TEMPLATE_TEST_NAME }}" --force
+      - specs template use "{{ .SPECS_TEMPLATE_TEST_NAME }}" "../{{ .SPECS_TEMPLATE_TEST_NAME }}" --use-defaults
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" commit -m "Initial commit"
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" remote add origin git@github.com:specsnl/laravel-project-test.git
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" fetch
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" branch --set-upstream-to=origin/main main
+      - code "../{{ .SPECS_TEMPLATE_TEST_NAME }}"
 
   test:interactive:
     desc: Test the specs template interactivly
-    deps: [cleanup:ignored, test:cleanup]
+    deps: [ cleanup:ignored, test:cleanup ]
     interactive: true
     cmds:
-      - specs template save . "{{.SPECS_TEMPLATE_TEST_NAME}}" --force
-      - specs template use "{{.SPECS_TEMPLATE_TEST_NAME}}" "../{{.SPECS_TEMPLATE_TEST_NAME}}"
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" init
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" add .
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" commit -m "Initial commit"
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" remote add origin git@github.com:specsnl/laravel-project-test.git
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" fetch
-      - git -C "../{{.SPECS_TEMPLATE_TEST_NAME}}" branch --set-upstream-to=origin/main main
-      - code "../{{.SPECS_TEMPLATE_TEST_NAME}}"
+      - specs template save . "{{ .SPECS_TEMPLATE_TEST_NAME }}" --force
+      - specs template use "{{ .SPECS_TEMPLATE_TEST_NAME }}" "../{{ .SPECS_TEMPLATE_TEST_NAME }}"
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" init
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" add .
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" commit -m "Initial commit"
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" remote add origin git@github.com:specsnl/laravel-project-test.git
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" fetch
+      - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" branch --set-upstream-to=origin/main main
+      - code "../{{ .SPECS_TEMPLATE_TEST_NAME }}"
 
   test:cleanup:
     desc: Cleanup specs template test files
     dir: ..
     status:
-       - test ! -d "{{.SPECS_TEMPLATE_TEST_NAME}}"
+       - test ! -d "{{ .SPECS_TEMPLATE_TEST_NAME }}"
     cmds:
-      - cd "{{.SPECS_TEMPLATE_TEST_NAME}}" && task down && task down
-      - rm -rf "{{.SPECS_TEMPLATE_TEST_NAME}}"
-      - specs template delete "{{.SPECS_TEMPLATE_TEST_NAME}}"
+      - cd "{{ .SPECS_TEMPLATE_TEST_NAME }}" && task down && task down
+      - rm -rf "{{ .SPECS_TEMPLATE_TEST_NAME }}"
+      - specs template delete "{{ .SPECS_TEMPLATE_TEST_NAME }}"

--- a/project.yml
+++ b/project.yml
@@ -40,9 +40,9 @@ computed:
     [[ .ProjectShortName | toSnakeCase ]]
   DbPassword: password
 
-  Php85DockerTag: "0.5.5" # Latest version: https://github.com/specsnl/php85/releases/latest
-  Php84DockerTag: "1.5.5" # Latest version: https://github.com/specsnl/php84/releases/latest
-  Php83DockerTag: "1.8.5" # Latest version: https://github.com/specsnl/php83/releases/latest
+  Php85DockerTag: "0.5.6" # Latest version: https://github.com/specsnl/php85/releases/latest
+  Php84DockerTag: "1.5.6" # Latest version: https://github.com/specsnl/php84/releases/latest
+  Php83DockerTag: "1.8.6" # Latest version: https://github.com/specsnl/php83/releases/latest
   PhpDockerTag: >-
     [[ eq .PhpVersion "8.4" | ternary .Php84DockerTag (eq .PhpVersion "8.3" | ternary .Php83DockerTag .Php85DockerTag) ]]
 

--- a/project.yml
+++ b/project.yml
@@ -48,6 +48,7 @@ computed:
 
 hooks:
   post-use:
+    - task setup:env-file:local
     - task md:fixstyle
     - git init
     - git add .

--- a/template/.taskfiles/Taskfile.artisan.yml
+++ b/template/.taskfiles/Taskfile.artisan.yml
@@ -2,6 +2,7 @@
 version: '3.50'
 
 tasks:
+
   run:*:
     desc: Run an artisan command inside the php service
     interactive: true

--- a/template/.taskfiles/Taskfile.cleanup.yml
+++ b/template/.taskfiles/Taskfile.cleanup.yml
@@ -2,6 +2,7 @@
 version: '3.50'
 
 tasks:
+
   files:
     desc: Cleanup of almost all gitignored files and untracked files
     prompt: This could potentially delete untracked files!! Do you want to continue?
@@ -32,6 +33,7 @@ tasks:
 
   auth:
     desc: Delete the local auth.json file.
+    run: once
     status:
       - test ! -f auth.json
       - test ! -d auth.json

--- a/template/.taskfiles/Taskfile.composer.yml
+++ b/template/.taskfiles/Taskfile.composer.yml
@@ -2,7 +2,24 @@
 version: '3.50'
 
 tasks:
-  do:*:
+
+  install:
+    desc: Install composer dependencies
+    preconditions:
+      - sh: test -f auth.json
+        msg: 'Missing auth.json file. Please run task setup:auth!'
+    cmds:
+      - task: cmd:install
+
+  update:
+    desc: Install composer dependencies (including all dependencies)
+    cmds:
+      - task: :setup:auth
+      - task: :dc:run:php-exec
+        vars:
+          SUB_CMD: 'composer update --with-all-dependencies'
+
+  cmd:*:
     desc: Run a composer command inside the php service
     vars:
       COMPOSER_CMD: '{{ index .MATCH 0 }}'
@@ -12,31 +29,12 @@ tasks:
           SUB_CMD: 'composer {{ .COMPOSER_CMD }} {{ .SUB_CMD }}'
           CLI_ARGS: '{{ .CLI_ARGS }}'
 
-  install:
-    desc: Install composer dependencies
-    preconditions:
-      - sh: test -f auth.json
-        msg: 'Missing auth.json file. Please run task setup:auth!'
-    cmds:
-      - task: do:install
-
-  update:
-    desc: Install composer dependencies (including all dependencies)
-    cmds:
-      - task: :dc:run:php-exec
-        vars:
-          SUB_CMD: 'composer update --with-all-dependencies'
-
-  validate:
-    desc: Validate composer.json
-    cmds:
-      - task: do:validate
-
-  run:*:
+  script:*:
     desc: Run a composer script
     vars:
       SCRIPT: '{{ index .MATCH 0 }}'
     cmds:
-      - task: do:run
+      - task: cmd:run
         vars:
           SUB_CMD: '{{ .SCRIPT }}'
+          CLI_ARGS: '-- {{ .CLI_ARGS }}'

--- a/template/.taskfiles/Taskfile.db.yml
+++ b/template/.taskfiles/Taskfile.db.yml
@@ -2,6 +2,7 @@
 version: '3.50'
 
 tasks:
+
   migrate:*:
     desc: Run migrations
     vars:

--- a/template/.taskfiles/Taskfile.md.yml
+++ b/template/.taskfiles/Taskfile.md.yml
@@ -2,6 +2,7 @@
 version: '3.50'
 
 tasks:
+
   checkstyle:
     desc: Check style of Markdown files
     cmds:
@@ -20,6 +21,7 @@ tasks:
   fix-tables:
     desc: Fix table spacing in markdown files
     cmds:
+      - task: :setup:auth
       - task: :dc:run:php-exec
         vars:
           SUB_CMD: bash -c "shopt -s globstar && npx --yes markdown-table-formatter **/*.md"

--- a/template/.taskfiles/Taskfile.npm.yml
+++ b/template/.taskfiles/Taskfile.npm.yml
@@ -2,7 +2,32 @@
 version: '3.50'
 
 tasks:
-  do:*:
+
+  install:
+    desc: Install node dependencies
+    cmds:
+      - task: cmd:ci
+        vars:
+          SUB_CMD: '--no-fund'
+
+  update:
+    desc: Update node dependencies
+    cmds:
+      - task: :setup:auth
+      - task: :dc:run:php-exec
+        vars:
+          SUB_CMD: 'npm update'
+
+  corepack:update:
+    aliases: [ corepack:up ]
+    desc: Run corepack up
+    cmds:
+      - task: :dc:run:php
+        vars:
+          SUB_CMD: 'corepack up'
+          CLI_ARGS: '{{ .CLI_ARGS }}'
+
+  cmd:*:
     desc: Run a NPM command inside the php service
     vars:
       NPM_CMD: '{{ index .MATCH 0 }}'
@@ -12,31 +37,12 @@ tasks:
           SUB_CMD: 'npm {{ .NPM_CMD }} {{ .SUB_CMD }}'
           CLI_ARGS: '{{ .CLI_ARGS }}'
 
-  install:
-    desc: Install node dependencies
-    cmds:
-      - task: do:ci
-
-  update:
-    desc: Update node dependencies
-    cmds:
-      - task: :dc:run:php-exec
-        vars:
-          SUB_CMD: 'npm update'
-
-  run:*:
+  script:*:
     desc: Run a NPM script
     vars:
       SCRIPT: '{{ index .MATCH 0 }}'
     cmds:
-      - task: do:run
-        vars: { SUB_CMD: '{{ .SCRIPT }}' }
-
-  corepack:update:
-    aliases: [corepack:up]
-    desc: Run corepack up
-    cmds:
-      - task: :dc:run:php
+      - task: cmd:run
         vars:
-          SUB_CMD: 'corepack up'
-          CLI_ARGS: '{{ .CLI_ARGS }}'
+          SUB_CMD: '{{ .SCRIPT }}'
+          CLI_ARGS: '-- {{ .CLI_ARGS }}'

--- a/template/.taskfiles/Taskfile.setup.yml
+++ b/template/.taskfiles/Taskfile.setup.yml
@@ -2,6 +2,7 @@
 version: '3.50'
 
 tasks:
+
   if-not-exist:
     desc: Setup development environment only if it wasn't already setup before
     internal: true
@@ -20,7 +21,7 @@ tasks:
       - task: auth
       - task: init:composer-lock
       - task: init:npm-lock
-      - task: :dc:build
+      - task: :build
         if: '[ "${GITHUB_ACTIONS:-}" != "true" ]'
       - task: env-file:local
       - task: env-file:testing
@@ -35,7 +36,7 @@ tasks:
         vars: { SUB_CMD: 'bash -c "wait-for-it [[ .DbHost ]]:[[ .DbPort ]] --timeout=0 --strict -- echo \"Done waiting\""' }
       - task: :db:migrate-fresh:local
       - task: :db:migrate-fresh:testing
-      - task: :npm:run:build
+      - task: :npm:script:build
 
   init:composer-lock:
     desc: Run composer update if composer.lock does not exist yet

--- a/template/Taskfile.dist.yml
+++ b/template/Taskfile.dist.yml
@@ -23,6 +23,7 @@ includes:
   cleanup: .taskfiles/Taskfile.cleanup.yml
 
 tasks:
+
   dc:
     internal: true
     vars:
@@ -41,33 +42,35 @@ tasks:
         {{ end }}
         {{ .SUB_CMD }} {{ .CLI_ARGS }}
 
-  dc:run:php-exec:
-    cmds:
-      - task: setup:auth
-      - task: dc
-        vars:
-          SUB_CMD: 'run --rm --user $(id -u):$(id -g) php-exec {{ .SUB_CMD }}'
-          CLI_ARGS: '{{ .CLI_ARGS }}'
-
   dc:run:*:
     interactive: true
     vars:
       SERVICE: '{{ index .MATCH 0 }}'
+      RUN_FLAGS: '{{ .RUN_FLAGS | default "" }}'
+      USER_FLAG: '{{ (ne (.NON_ROOT | default "true") "false") | ternary " --user $(id -u):$(id -g)" "" }}'
+      COMPOSE_SERVICES:
+        sh: COMPOSE_PROFILES="*" docker compose config --services
     cmds:
       - task: dc
         vars:
-          SUB_CMD: 'run --rm --user $(id -u):$(id -g) {{ .SERVICE }} {{ .SUB_CMD }}'
+          SUB_CMD: 'run --rm {{ .RUN_FLAGS }} {{ .USER_FLAG }} {{ .SERVICE }} {{ .SUB_CMD }}'
           CLI_ARGS: '{{ .CLI_ARGS }}'
+    requires:
+      vars:
+        - name: SERVICE
+          enum:
+            ref: .COMPOSE_SERVICES | splitLines | compact
 
-  dc:build:
+  build:
     desc: Build all docker images
-    deps: [setup:env-file:local]
+    deps: [ setup:env-file:local ]
     preconditions:
       - sh: test -f auth.json
         msg: Create an auth.json file by running "task setup:auth".
     cmds:
       - task: dc
-        vars: { SUB_CMD: 'build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)' }
+        vars:
+          SUB_CMD: 'build --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)'
 
   up:
     desc: Start development environment
@@ -76,13 +79,15 @@ tasks:
       - task: setup:env-file:testing
       - task: setup:if-not-exist
       - task: dc
-        vars: { SUB_CMD: 'up -d' }
+        vars:
+          SUB_CMD: 'up -d'
 
   stop:
     desc: Stop development environment
     cmds:
       - task: dc
-        vars: { SUB_CMD: "stop" }
+        vars:
+          SUB_CMD: 'stop'
 
   restart:
     desc: Restart development environment
@@ -94,7 +99,8 @@ tasks:
     desc: Down the development environment
     cmds:
       - task: dc
-        vars: { SUB_CMD: 'down --volumes --remove-orphans' }
+        vars:
+          SUB_CMD: 'down --volumes --remove-orphans'
 
   reset:
     desc: Reset the development environment
@@ -104,16 +110,18 @@ tasks:
 
   ps:
     desc: Show all project container (including stopped ones)
-    aliases: [status]
+    aliases: [ status ]
     cmds:
       - task: dc
-        vars: { SUB_CMD: 'ps -a' }
+        vars:
+          SUB_CMD: 'ps -a'
 
   logs:
     desc: Show logs of all project containers
     cmds:
       - task: dc
-        vars: { SUB_CMD: 'logs -f' }
+        vars:
+          SUB_CMD: 'logs -f'
 
   shell:
     desc: Open a bash shell to the php service
@@ -132,8 +140,9 @@ tasks:
   checkall:
     desc: Run all checks
     cmds:
-      - task: composer:run:checkall
-        vars: { CLI_ARGS: '' }
+      - task: composer:script:checkall
+        vars:
+          CLI_ARGS: ''
       - task: md:checkstyle
 
   refresh:
@@ -146,4 +155,4 @@ tasks:
       # We are only adding new migrations and not running migrate:refresh so we don't lose our data for the dev environment:
       - task: db:migrate:local
       - task: db:migrate-fresh:testing
-      - task: npm:run:build
+      - task: npm:script:build

--- a/template/composer.json
+++ b/template/composer.json
@@ -82,7 +82,7 @@
         ],
         "test-report": [
             "Composer\\Config::disableProcessTimeout",
-            "XDEBUG_MODE=off CREATE_SNAPSHOTS=false php -dpcov.enabled=1 -dpcov.directory=. vendor/bin/phpunit --coverage-text --show-uncovered-for-coverage-text --coverage-html coverage/html"
+            "XDEBUG_MODE=off CREATE_SNAPSHOTS=false php -dpcov.enabled=1 -dpcov.directory=. vendor/bin/phpunit --coverage-text --show-uncovered-for-coverage-text --coverage-html coverage/html --coverage-clover coverage/clover-test-report.xml"
         ],
         "checkstyle": "XDEBUG_MODE=off phpcs -n",
         "fixstyle": "XDEBUG_MODE=off phpcbf -n",

--- a/template/rector.php
+++ b/template/rector.php
@@ -23,6 +23,12 @@ return RectorConfig::configure()
         __DIR__ . '/bootstrap/cache',
         __DIR__ . '/config/ide-helper.php',
     ])
+    ->withPHPStanConfigs([
+        __DIR__ . '/vendor/larastan/larastan/extension.neon',
+    ])
+    ->withBootstrapFiles([
+        __DIR__ . '/vendor/larastan/larastan/bootstrap.php',
+    ])
     ->withSetProviders(LaravelSetProvider::class)
     ->withComposerBased(phpunit: true, laravel: true)
     ->withAttributesSets()


### PR DESCRIPTION
## Summary

- **Taskfile refactoring** — Renamed `do:*` → `cmd:*` and `run:*` → `script:*` across composer and npm taskfiles for clearer naming. Renamed `dc:build` → `build`. Merged `dc:run:php-exec` into the unified `dc:run:*` task with `RUN_FLAGS` / `USER_FLAG` vars and a `requires` block that validates the service name against the live compose config (fixes wrong-project container creation). Consistent formatting throughout: spaces inside template `{{ .VAR }}` and array `[ task ]` syntax.
- **PHP image tag bumps** — PHP 8.3 → 1.8.6, 8.4 → 1.5.6, 8.5 → 0.5.6.
- **Clover test report** — Added `--coverage-clover coverage/clover-test-report.xml` to the `test-report` composer script for easier single-file parsing by LLMs.
- **Rector + Larastan** — Rector is now bootstrapped with the Larastan extension and bootstrap file so it benefits from Laravel-aware type inference during analysis.
- **Post-use hook** — Added `task setup:env-file:local` as the first post-use hook step so the local env file is always created when the template is applied.
- **`cleanup:auth` dedup** — Added `run: once` so the task is not executed multiple times when called as a dependency from several tasks in the same run.
- **`md:fix-tables` auth** — Added `setup:auth` dependency so npm can pull the markdown-table-formatter package in environments that require auth.
