### PR TITLE
Add filament template option

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -1,7 +1,7 @@
 # https://taskfile.dev
 version: '3.50'
 
-silent: true
+# silent: true
 
 vars:
   SPECS_TEMPLATE_NAME: laravel-13-project
@@ -37,7 +37,7 @@ tasks:
     deps: [ cleanup:ignored, test:cleanup ]
     cmds:
       - specs template save . "{{ .SPECS_TEMPLATE_TEST_NAME }}" --force
-      - specs template use "{{ .SPECS_TEMPLATE_TEST_NAME }}" "../{{ .SPECS_TEMPLATE_TEST_NAME }}" --use-defaults
+      - specs template use "{{ .SPECS_TEMPLATE_TEST_NAME }}" "../{{ .SPECS_TEMPLATE_TEST_NAME }}" --use-defaults {{ .CLI_ARGS }}
       - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" commit -m "Initial commit"
       - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" remote add origin git@github.com:specsnl/laravel-project-test.git
       - git -C "../{{ .SPECS_TEMPLATE_TEST_NAME }}" fetch

--- a/project.yml
+++ b/project.yml
@@ -19,6 +19,7 @@ Database:
   - mariadb
   - mysql
 AddBugSnag: false
+AddFilament: false
 
 computed:
   DockerDbPort: >-

--- a/project.yml
+++ b/project.yml
@@ -3,7 +3,7 @@ __delimiters:
   right: "]]"
 
 ProjectName: My Acme Project
-ProjectShortName: acme-12
+ProjectShortName: acme
 ProjectDescription: This Laravel project is scaffolded using specsnl/specs-cli using the specsnl/specs-laravel-project.
 PhpVersion:
   - "8.5"

--- a/template/.env.example
+++ b/template/.env.example
@@ -95,7 +95,7 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
 
-[[- if eq .AddBugSnag true ]]
+[[- if .AddBugSnag ]]
 
 # Bugsnag
 BUGSNAG_API_KEY=

--- a/template/[[`.gitignore`]]
+++ b/template/[[`.gitignore`]]
@@ -36,6 +36,9 @@ phpstan.neon
 # Custom
 public/css
 public/js
+[[- if .AddFilament ]]
+public/fonts/filament
+[[- end ]]
 
 _ide_helper_models.php
 _ide_helper.php

--- a/template/app/Models/User.php
+++ b/template/app/Models/User.php
@@ -7,6 +7,10 @@ namespace App\Models;
 use Carbon\CarbonImmutable;
 use Database\Factories\UserFactory;
 use Eloquent;
+[[- if .AddFilament ]]
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
+[[- end ]]
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Builder;
@@ -44,7 +48,7 @@ use Override;
     'password',
     'remember_token',
 ])]
-class User extends Authenticatable
+class User extends Authenticatable[[ if .AddFilament ]] implements FilamentUser[[ end ]]
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory;
@@ -63,4 +67,12 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    [[- if .AddFilament ]]
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return true;
+    }
+    [[- end ]]
 }

--- a/template/app/Providers/[[ if .AddFilament ]]Filament[[ end ]]/DashboardPanelProvider.php
+++ b/template/app/Providers/[[ if .AddFilament ]]Filament[[ end ]]/DashboardPanelProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers\Filament;
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\AuthenticateSession;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Pages\Dashboard;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Support\Colors\Color;
+use Filament\Widgets\AccountWidget;
+use Filament\Widgets\FilamentInfoWidget;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+class DashboardPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->default()
+            ->id('dashboard')
+            ->path('dashboard')
+            ->login()
+            ->colors([
+                'primary' => Color::Amber,
+            ])
+            ->discoverResources(in: app_path('Filament/Resources'), for: 'App\Filament\Resources')
+            ->discoverPages(in: app_path('Filament/Pages'), for: 'App\Filament\Pages')
+            ->pages([
+                Dashboard::class,
+            ])
+            ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets')
+            ->widgets([
+                AccountWidget::class,
+                FilamentInfoWidget::class,
+            ])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                PreventRequestForgery::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+    }
+}

--- a/template/boost.json
+++ b/template/boost.json
@@ -7,6 +7,11 @@
     "guidelines": true,
     "mcp": true,
     "nightwatch_mcp": false,
+    [[- if .AddFilament ]]
+    "packages": [
+        "filament/filament"
+    ],
+    [[- end ]]
     "sail": false,
     "skills": [
         "laravel-best-practices",

--- a/template/bootstrap/providers.php
+++ b/template/bootstrap/providers.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use App\Providers\AppServiceProvider;
+[[- if .AddFilament ]]
+use App\Providers\Filament\DashboardPanelProvider;
+[[- end ]]
 [[- if .AddBugSnag ]]
 use Bugsnag\BugsnagLaravel\BugsnagServiceProvider;
 [[- end ]]
@@ -12,4 +15,7 @@ return [
     BugsnagServiceProvider::class,
     [[- end ]]
     AppServiceProvider::class,
+    [[- if .AddFilament ]]
+    DashboardPanelProvider::class,
+    [[- end ]]
 ];

--- a/template/composer.json
+++ b/template/composer.json
@@ -14,6 +14,9 @@
         [[- if .AddBugSnag ]]
         "bugsnag/bugsnag-laravel": "^2.3",
         [[- end ]]
+        [[- if .AddFilament ]]
+        "filament/filament": "^5.0",
+        [[- end ]]
         "laravel/framework": "^13.0",
         "laravel/tinker": "^3.0.0",
         "webmozart/assert": "^2.0.0"
@@ -58,7 +61,9 @@
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi",
             "[ \"$COMPOSER_DEV_MODE\" = \"1\" ] && $PHP_BINARY artisan ide-helper:generate || true",
-            "[ \"$COMPOSER_DEV_MODE\" = \"1\" ] && $PHP_BINARY artisan ide-helper:meta || true"
+            "[ \"$COMPOSER_DEV_MODE\" = \"1\" ] && $PHP_BINARY artisan ide-helper:meta || true"[[ if .AddFilament ]],
+            "@php artisan filament:upgrade"
+            [[- end ]]
         ],
         "post-install-cmd": [
             "[ \"$COMPOSER_DEV_MODE\" = \"1\" ] && $PHP_BINARY artisan boost:update --ansi || true"


### PR DESCRIPTION
## Summary

Adds an optional `AddFilament` template flag that wires up a full [Filament](https://filamentphp.com/) admin panel when enabled.

### Changes

**New `AddFilament` option** (`project.yml`)
- Defaults to `false`; set to `true` to include Filament in the generated project

**When `AddFilament` is enabled, the following is scaffolded:**
- `filament/filament: ^5.0` added to `composer.json` require dependencies
- `@php artisan filament:upgrade` added to the `post-autoload-dump` scripts
- `DashboardPanelProvider` created in `app/Providers/Filament/` with a default dashboard panel configuration
- `DashboardPanelProvider` registered in `bootstrap/providers.php`
- `User` model implements `FilamentUser` and adds `canAccessPanel()` method
- `public/fonts/filament` added to `.gitignore`
- `filament/filament` added to `boost.json` packages list

**Other fixes**
- Fix BugSnag template condition: `[[- if eq .AddBugSnag true ]]` → `[[- if .AddBugSnag ]]` for consistency with Go template idioms
- Update default `ProjectShortName` from `acme-12` to `acme`
- Pass `{{ .CLI_ARGS }}` to `specs template use` in the Taskfile test task to allow forwarding extra flags during testing