### PR TITLE
Added e2e setup as an option

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -20,6 +20,7 @@ Database:
   - mysql
 AddBugSnag: false
 AddFilament: false
+AddE2E: false
 
 computed:
   DockerDbPort: >-

--- a/template/.github/rulesets/Main.json
+++ b/template/.github/rulesets/Main.json
@@ -25,6 +25,12 @@
                 "strict_required_status_checks_policy": false,
                 "do_not_enforce_on_create": false,
                 "required_status_checks": [
+                    [[- if .AddE2E ]]
+                    {
+                        "context": "Check E2E tests",
+                        "integration_id": 15368
+                    },
+                    [[- end ]]
                     {
                         "context": "Check PR Title",
                         "integration_id": 15368

--- a/template/.github/rulesets/Release branches.json
+++ b/template/.github/rulesets/Release branches.json
@@ -25,6 +25,12 @@
                 "strict_required_status_checks_policy": false,
                 "do_not_enforce_on_create": true,
                 "required_status_checks": [
+                    [[- if .AddE2E ]]
+                    {
+                        "context": "Check E2E tests",
+                        "integration_id": 15368
+                    },
+                    [[- end ]]
                     {
                         "context": "Check Model DocBlocks",
                         "integration_id": 15368

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -248,3 +248,48 @@ jobs:
             echo "Make sure your local database is up to date and the migrations are in sync with the database."
             exit 1
           fi
+[[- if .AddE2E ]]
+
+  e2e-check-tests:
+    name: Check E2E tests
+    runs-on: ubuntu-24.04
+    needs: [setup-npm-cache, setup-composer-cache]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create auth.json
+        env:
+          COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
+        run: echo "$COMPOSER_AUTH_JSON" > auth.json
+      - name: Setup Node (warms ~/.npm for Docker npm cache mount)
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          registry-url: https://npm.pkg.github.com
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Task
+        uses: go-task/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Start the project using Task
+        run: task ci:up
+      - name: Seed the e2e fixture (deterministic users)
+        run: task 'artisan:run:db:seed' -- --class='Database\Seeders\E2ETestSeeder'
+      - name: Run E2E tests
+        run: task e2e:docker:test
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: playwright-report/
+[[- end ]]

--- a/template/.taskfiles/[[ if .AddE2E ]]Taskfile.e2e.yml[[ end ]]
+++ b/template/.taskfiles/[[ if .AddE2E ]]Taskfile.e2e.yml[[ end ]]
@@ -1,0 +1,39 @@
+# https://taskfile.dev
+version: '3.50'
+
+tasks:
+  setup:
+    desc: Install Playwright browsers (for running on the host)
+    aliases: [ install ]
+    cmds:
+      - rm -rf node_modules 2> /dev/null
+      - npm ci
+      - npm run test:e2e:install
+
+  test:
+    aliases: [ test:ui ]
+    desc: Run Playwright tests using the UI (host)
+    cmds:
+      - npm run test:e2e:ui
+
+  test:headless:
+    desc: Run Playwright tests headless (host)
+    cmds:
+      - npm run test:e2e
+
+  codegen:
+    desc: Playwright code-gen
+    cmds:
+      - npm run test:e2e:codegen
+
+  show-report:
+    desc: Show the Playwright test report
+    cmds:
+      - npm run test:e2e:report
+
+  docker:test:
+    desc: Run E2E tests with Playwright in Docker (against the running stack)
+    cmds:
+      - task: :dc:run:e2e-playwright
+        vars:
+          SUB_CMD: npm run test:e2e

--- a/template/README.md
+++ b/template/README.md
@@ -59,3 +59,21 @@ instance (re)fetch the composer and npm dependencies, run the migrations and reb
 #### Using Clockwork to debug the application
 
 Checkout <https://[[ .ProjectShortName | toKebabCase ]].local/clockwork> to see the [clockwork](https://underground.works/clockwork/) dashboard.
+[[- if .AddE2E ]]
+
+### End-to-end testing (Playwright)
+
+End-to-end tests live in the `e2e/` directory and run with [Playwright](https://playwright.dev/).
+
+To run them on your host, first install the browsers once with `task e2e:setup`, then:
+
+- `task e2e:test` — run the tests in the Playwright UI
+- `task e2e:test:headless` — run the tests headless
+- `task e2e:codegen` — record a test by interacting with the app
+- `task e2e:show-report` — open the last HTML report
+
+To run the suite in Docker against the running stack (as CI does), use `task e2e:docker:test`.
+
+A deterministic fixture user is available via `Database\Seeders\E2ETestSeeder`; seed it
+with `task artisan:run:db:seed -- --class='Database\Seeders\E2ETestSeeder'`.
+[[- end ]]

--- a/template/Taskfile.dist.yml
+++ b/template/Taskfile.dist.yml
@@ -18,6 +18,9 @@ includes:
   artisan: .taskfiles/Taskfile.artisan.yml
   npm: .taskfiles/Taskfile.npm.yml
   db: .taskfiles/Taskfile.db.yml
+[[- if .AddE2E ]]
+  e2e: .taskfiles/Taskfile.e2e.yml
+[[- end ]]
   setup: .taskfiles/Taskfile.setup.yml
   md: .taskfiles/Taskfile.md.yml
   cleanup: .taskfiles/Taskfile.cleanup.yml
@@ -81,6 +84,25 @@ tasks:
       - task: dc
         vars:
           SUB_CMD: 'up -d'
+[[- if .AddE2E ]]
+
+  ci:up:
+    desc: Start the environment on a fresh CI runner (skips the setup:if-not-exist guard)
+    cmds:
+      - task: setup:env-file:local
+      - task: setup:env-file:testing
+      - task: composer:install
+      - task: npm:install
+      - task: dc
+        vars: { SUB_CMD: 'up -d' }
+      - task: artisan:run:key:generate
+      - task: artisan:run:storage:link
+        vars: { SUB_CMD: '--quiet' }
+      - task: dc:run:php
+        vars: { SUB_CMD: 'bash -c "wait-for-it [[ .DbHost ]]:[[ .DbPort ]] --timeout=0 --strict -- echo \"Done waiting\""' }
+      - task: db:migrate-fresh:local
+      - task: npm:script:build
+[[- end ]]
 
   stop:
     desc: Stop development environment

--- a/template/[[ if .AddE2E ]]e2e[[ end ]]/example.spec.ts
+++ b/template/[[ if .AddE2E ]]e2e[[ end ]]/example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Smoke', () => {
+    test('welcome page loads', async ({ page }) => {
+        await page.goto('/');
+        await expect(page).toHaveTitle(/[[ .ProjectName ]]|Laravel/);
+    });
+});

--- a/template/[[ if .AddE2E ]]e2e[[ end ]]/helpers.ts
+++ b/template/[[ if .AddE2E ]]e2e[[ end ]]/helpers.ts
@@ -1,0 +1,24 @@
+// import { Page } from '@playwright/test';
+
+/**
+ * Credentials seeded by Database\Seeders\E2ETestSeeder (password "password").
+ */
+export const E2E_USER = { email: 'e2e@example.com', password: 'password' };
+
+/**
+ * Log a user in through the application's login form.
+ *
+ * A freshly scaffolded project ships without auth UI, so this helper is left
+ * commented out as a starting point. Once you add authentication (Breeze,
+ * Fortify, Filament, laravel/ui, ...), uncomment this and adapt the selectors
+ * to match your login page, then use it from your specs:
+ *
+ *     import { E2E_USER, login } from './helpers';
+ *     await login(page, E2E_USER);
+ */
+// export async function login(page: Page, user: { email: string; password: string }): Promise<void> {
+//     await page.goto('/login');
+//     await page.getByLabel('Email').fill(user.email);
+//     await page.getByLabel('Password').fill(user.password);
+//     await page.getByRole('button', { name: 'Log in' }).click();
+// }

--- a/template/[[ if .AddE2E ]]playwright.config.ts[[ end ]]
+++ b/template/[[ if .AddE2E ]]playwright.config.ts[[ end ]]
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ *
+ * BASE_URL is injected by the `e2e-playwright` compose service. When running on
+ * the host it falls back to the local OrbStack domain.
+ */
+const baseURL = process.env.BASE_URL ?? 'http://[[ .ProjectShortName | toKebabCase ]].local';
+
+export default defineConfig({
+    testDir: './e2e',
+    /* Run tests in files in parallel */
+    fullyParallel: true,
+    /* Fail the build on CI if you accidentally left test.only in the source code. */
+    forbidOnly: !!process.env.CI,
+    /* Retry on CI only */
+    retries: process.env.CI ? 2 : 0,
+    /* Opt out of parallel tests on CI. */
+    workers: process.env.CI ? 1 : undefined,
+    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+    reporter: 'html',
+    /* Shared settings for all the projects below. */
+    use: {
+        baseURL,
+        /* Collect trace when retrying the failed test. */
+        trace: 'on-first-retry',
+        viewport: { width: 1920, height: 1080 },
+    },
+
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+});

--- a/template/[[`.gitignore`]]
+++ b/template/[[`.gitignore`]]
@@ -39,6 +39,12 @@ public/js
 [[- if .AddFilament ]]
 public/fonts/filament
 [[- end ]]
+[[- if .AddE2E ]]
+/test-results
+/playwright-report
+/playwright/.cache
+/playwright/.auth
+[[- end ]]
 
 _ide_helper_models.php
 _ide_helper.php

--- a/template/compose.mounts.yml
+++ b/template/compose.mounts.yml
@@ -72,3 +72,10 @@ services:
   markdown-linter:
     volumes:
       - ./:/workdir
+[[- if .AddE2E ]]
+
+  e2e-playwright:
+    volumes:
+      - ./:/var/www/
+      - [[ .ProjectShortName | toSnakeCase ]]_cache:/cache
+[[- end ]]

--- a/template/compose.yml
+++ b/template/compose.yml
@@ -56,6 +56,12 @@ services:
     labels:
       - dev.orbstack.domains=[[ .ProjectShortName | toKebabCase ]].local
       - dev.orbstack.http-port=80
+[[- if .AddE2E ]]
+    networks:
+      default:
+        aliases:
+          - [[ .ProjectShortName | toKebabCase ]].local
+[[- end ]]
 
 [[- if eq .Database "postgres" ]]
 
@@ -105,3 +111,14 @@ services:
   markdown-linter:
     image: davidanson/markdownlint-cli2:v0.22.1
     profiles: [markdown-lint]
+[[- if .AddE2E ]]
+
+  e2e-playwright:
+    profiles: [e2e]
+    image: mcr.microsoft.com/playwright:v1.61.0-noble
+    working_dir: /var/www
+    depends_on:
+      - nginx
+    environment:
+      BASE_URL: http://[[ .ProjectShortName | toKebabCase ]].local
+[[- end ]]

--- a/template/database/seeders/[[ if .AddE2E ]]E2ETestSeeder.php[[ end ]]
+++ b/template/database/seeders/[[ if .AddE2E ]]E2ETestSeeder.php[[ end ]]
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+/**
+ * Deterministic fixture for the Playwright e2e suite.
+ *
+ * Run it on top of a fresh database, e.g.:
+ *
+ *     php artisan migrate:fresh
+ *     php artisan db:seed --class=Database\\Seeders\\E2ETestSeeder
+ *
+ * Extend this with whatever fixed users / records your specs assert against.
+ * The seeded user shares the password "password".
+ */
+class E2ETestSeeder extends Seeder
+{
+    public const string USER_EMAIL = 'e2e@example.com';
+
+    public const string PASSWORD = 'password';
+
+    public function run(): void
+    {
+        User::factory()->create([
+            'name' => 'E2E User',
+            'email' => self::USER_EMAIL,
+        ]);
+    }
+}

--- a/template/package.json
+++ b/template/package.json
@@ -6,9 +6,20 @@
     "scripts": {
         "build": "vite build",
         "watch": "vite build --watch",
-        "dev": "vite"
+        "dev": "vite"[[ if .AddE2E ]],
+        "test:e2e:install": "playwright install --with-deps chromium",
+        "test:e2e": "playwright test",
+        "test:e2e:ui": "playwright test --ui",
+        "test:e2e:headed": "playwright test --headed",
+        "test:e2e:debug": "playwright test --debug",
+        "test:e2e:report": "playwright show-report",
+        "test:e2e:codegen": "npx playwright codegen --viewport-size=1920,1080"[[ end ]]
     },
     "devDependencies": {
+        [[- if .AddE2E ]]
+        "@playwright/test": "^1.61.0",
+        "@types/node": "^24.0.0",
+        [[- end ]]
         "@tailwindcss/vite": "^4.0.0",
         "axios": "^1.11.0",
         "laravel-vite-plugin": "^3.1.0",


### PR DESCRIPTION
## What

Adds an optional Playwright end-to-end testing setup to the template, gated behind the new `AddE2E` toggle in `project.yml` (defaults to `false`). When enabled, a generated project gets a working e2e harness modelled on the proven `specs/ctm-dot` setup, but generalised for a blank Laravel app.

## Why

E2E coverage was being copied by hand into projects that wanted it. Making it a first-class template option means new projects can opt in at scaffold time and get a consistent, CI-wired Playwright setup out of the box.

## What's included (when `AddE2E: true`)

- **Playwright config** (`playwright.config.ts`) — chromium, 1920×1080, HTML reporter, CI retries; `BASE_URL` falls back to `http://<shortname>.local`.
- **Starter specs** — `e2e/example.spec.ts` (welcome-page smoke test that works on a fresh app) and `e2e/helpers.ts` (commented `login()` scaffold + seeded-user credentials).
- **Seeder** — `database/seeders/E2ETestSeeder.php`, a deterministic fixture (`e2e@example.com`) to extend.
- **Task targets** — `.taskfiles/Taskfile.e2e.yml` (`setup`, `test`, `test:headless`, `codegen`, `show-report`, `docker:test`) plus a new `ci:up` task.
- **Docker** — an `e2e-playwright` service (`profiles: [e2e]`) in `compose.yml`/`compose.mounts.yml`, plus an nginx network alias so the container resolves the app inside the compose network.
- **npm** — `@playwright/test` + `@types/node` devDeps and `test:e2e:*` scripts in `package.json`.
- **CI** — a gated `e2e-check-tests` job that boots the stack, seeds the fixture, runs the suite in Docker, and uploads the Playwright report.
- **Rulesets** — `Check E2E tests` added as a required status check in `Main.json` and `Release branches.json`.
- **Docs + ignores** — an "End-to-end testing" section in the README and Playwright artifact entries in `.gitignore`.

## Gating

Everything is wired with the existing boilr patterns: conditional filenames (`[[ if .AddE2E ]]…[[ end ]]`) for whole files/dirs and `[[- if .AddE2E ]]`/`[[- end ]]` blocks inside shared files. With `AddE2E: false` none of the above is emitted and `package.json`/`compose.yml`/rulesets stay valid (no dangling commas).

