### PR TITLE
Added git worktrees support

### DIFF
--- a/template/.taskfiles/Taskfile.worktrees.yml
+++ b/template/.taskfiles/Taskfile.worktrees.yml
@@ -1,0 +1,135 @@
+# https://taskfile.dev
+version: '3.50'
+
+vars:
+  # Canonical project name, baked in at scaffold time so it is independent of the
+  # current worktree's (patched) .env.
+  BASE_NAME: '[[ .ProjectShortName | toKebabCase ]]'
+  # The database host-port .env var name + its default value (rendered once at
+  # scaffold time, used when assigning unique ports without OrbStack).
+  DB_PORT_VAR: '[[ eq .Database "postgres" | ternary "DOCKER_POSTGRES_PORT" (eq .Database "mysql" | ternary "DOCKER_MYSQL_PORT" "DOCKER_MARIADB_PORT") ]]'
+  DB_BASE_PORT: '[[ .DockerDbPort ]]'
+  # Worktrees live in a sibling directory next to the main worktree, e.g.
+  # ../[[ .ProjectShortName | toKebabCase ]]-worktrees/<name>.
+  WORKTREE_ROOT:
+    sh: echo "$(dirname "$(git worktree list --porcelain | head -1 | cut -d' ' -f2)")/{{ .BASE_NAME }}-worktrees"
+
+tasks:
+
+  list:
+    desc: List all git worktrees
+    aliases: [ ls ]
+    cmds:
+      - git worktree list
+
+  create:
+    desc: Create an isolated worktree (own branch, .env, containers, domains and ports)
+    summary: |
+      Create a git worktree that can run its full Docker stack alongside the main
+      project without collisions.
+
+      Usage:
+        task worktrees:create NAME=my-feature          # new branch "my-feature"
+        task worktrees:create NAME=my-feature BRANCH=existing-branch
+
+      What it does:
+        - Adds a worktree at {{ .WORKTREE_ROOT }}/<slug>
+        - Generates a .env with a unique COMPOSE_PROJECT_NAME ({{ .BASE_NAME }}-<slug>),
+          which gives the worktree its own containers, network, volumes and
+          *.local OrbStack domains.
+        - Without OrbStack: also assigns unique host ports (printed at the end).
+        - Runs "task up" inside the worktree.
+
+      Note: if .env.example later changes (e.g. a project update), a subsequent
+      "task up" inside the worktree will re-copy it and reset COMPOSE_PROJECT_NAME;
+      re-run this task or re-patch .env if that happens.
+    requires:
+      vars: [ NAME ]
+    vars:
+      WT_BRANCH: '{{ .BRANCH | default .NAME }}'
+      SLUG:
+        sh: echo "{{ .NAME }}" | tr '[:upper:]' '[:lower:]' | sed -e 's#[^a-z0-9]#-#g' -e 's#--*#-#g' -e 's#^-##' -e 's#-$##'
+      PROJECT: '{{ .BASE_NAME }}-{{ .SLUG }}'
+      WT_PATH: '{{ .WORKTREE_ROOT }}/{{ .SLUG }}'
+    preconditions:
+      - sh: test -n "{{ .SLUG }}"
+        msg: 'NAME "{{ .NAME }}" produced an empty slug. Use a name containing letters or digits.'
+    cmds:
+      # 1. Create the worktree (new branch, or check out an existing one).
+      - |
+        if git show-ref --verify --quiet "refs/heads/{{ .WT_BRANCH }}"; then
+          git worktree add "{{ .WT_PATH }}" "{{ .WT_BRANCH }}"
+        else
+          git worktree add -b "{{ .WT_BRANCH }}" "{{ .WT_PATH }}"
+        fi
+      # 2. Seed the env files first. This records Task's checksum for .env.example so
+      #    the "task up" below treats env-file:local as up-to-date and does NOT
+      #    overwrite the COMPOSE_PROJECT_NAME we patch in step 3/4.
+      - task --dir "{{ .WT_PATH }}" setup:env-file:local
+      - task --dir "{{ .WT_PATH }}" setup:env-file:testing
+      # 3. Unique project name -> unique containers, network, volumes and domains.
+      - |
+        sed -e 's#^COMPOSE_PROJECT_NAME=.*#COMPOSE_PROJECT_NAME="{{ .PROJECT }}"#' \
+          "{{ .WT_PATH }}/.env" > "{{ .WT_PATH }}/.env.tmp" && mv "{{ .WT_PATH }}/.env.tmp" "{{ .WT_PATH }}/.env"
+      # 4a. OrbStack: unique *.local domain, no host ports needed.
+      - if: '[ "{{ .ORBSTACK_ENABLED }}" = "1" ]'
+        cmd: |
+          sed -e 's#^APP_URL=.*#APP_URL=https://{{ .PROJECT }}.local#' \
+            "{{ .WT_PATH }}/.env" > "{{ .WT_PATH }}/.env.tmp" && mv "{{ .WT_PATH }}/.env.tmp" "{{ .WT_PATH }}/.env"
+      # 4b. No OrbStack: assign unique host ports (deterministic offset from the slug).
+      - if: '[ "{{ .ORBSTACK_ENABLED }}" != "1" ]'
+        cmd: |
+          OFFSET=$(( $(echo -n "{{ .SLUG }}" | cksum | cut -d' ' -f1) % 1000 + 1 ))
+          NGINX_PORT=$(( 8080 + OFFSET ))
+          DB_PORT=$(( {{ .DB_BASE_PORT }} + OFFSET ))
+          REDIS_PORT=$(( 6379 + OFFSET ))
+          MAILPIT_PORT=$(( 8025 + OFFSET ))
+          sed -e "s#^DOCKER_NGINX_PORT=.*#DOCKER_NGINX_PORT=${NGINX_PORT}#" \
+              -e "s#^{{ .DB_PORT_VAR }}=.*#{{ .DB_PORT_VAR }}=${DB_PORT}#" \
+              -e "s#^DOCKER_REDIS_PORT=.*#DOCKER_REDIS_PORT=${REDIS_PORT}#" \
+              -e "s#^DOCKER_MAILPIT_PORT=.*#DOCKER_MAILPIT_PORT=${MAILPIT_PORT}#" \
+              -e "s#^APP_URL=.*#APP_URL=http://localhost:${NGINX_PORT}#" \
+            "{{ .WT_PATH }}/.env" > "{{ .WT_PATH }}/.env.tmp" && mv "{{ .WT_PATH }}/.env.tmp" "{{ .WT_PATH }}/.env"
+          echo "Assigned host ports -> nginx:${NGINX_PORT} db:${DB_PORT} redis:${REDIS_PORT} mailpit:${MAILPIT_PORT}"
+          echo "Verify these do not collide with other running worktrees."
+      # 5. Bring the worktree's stack up.
+      - task --dir "{{ .WT_PATH }}" up
+      - |
+        echo ""
+        echo "Worktree ready:"
+        echo "  path:    {{ .WT_PATH }}"
+        echo "  branch:  {{ .WT_BRANCH }}"
+        echo "  project: {{ .PROJECT }}"
+        [ "{{ .ORBSTACK_ENABLED }}" = "1" ] && echo "  url:     https://{{ .PROJECT }}.local"
+        echo ""
+        echo "Open it with: cd {{ .WT_PATH }}"
+
+  delete:
+    desc: Tear down a worktree's containers and remove the worktree
+    aliases: [ remove, rm ]
+    summary: |
+      Stops and removes the worktree's Docker stack (containers + volumes) and then
+      removes the git worktree.
+
+      Usage:
+        task worktrees:delete NAME=my-feature
+
+      The git branch is NOT deleted. Remove it separately with:
+        git branch -d <branch>
+    prompt: This tears down the worktree's containers/volumes and removes its directory. Continue?
+    requires:
+      vars: [ NAME ]
+    vars:
+      SLUG:
+        sh: echo "{{ .NAME }}" | tr '[:upper:]' '[:lower:]' | sed -e 's#[^a-z0-9]#-#g' -e 's#--*#-#g' -e 's#^-##' -e 's#-$##'
+      WT_PATH: '{{ .WORKTREE_ROOT }}/{{ .SLUG }}'
+    preconditions:
+      - sh: test -n "{{ .SLUG }}"
+        msg: 'NAME "{{ .NAME }}" produced an empty slug. Use a name containing letters or digits.'
+    cmds:
+      - if: test -d "{{ .WT_PATH }}"
+        cmd: task --dir "{{ .WT_PATH }}" down
+      # --force is required because worktrees always contain untracked files (vendor,
+      # node_modules, .env, ...). The prompt above guards against accidents.
+      - git worktree remove --force "{{ .WT_PATH }}"
+      - git worktree prune

--- a/template/README.md
+++ b/template/README.md
@@ -56,6 +56,22 @@ start the project up again.
 To refresh the project when for instance you are switching to a different branch, run `task app:refresh`. This will for
 instance (re)fetch the composer and npm dependencies, run the migrations and rebuild the front-end assets
 
+#### Working with git worktrees
+
+You can run several branches at the same time, each with its own containers, volumes and
+dependencies, using git worktrees. Every worktree gets a unique `COMPOSE_PROJECT_NAME`, so its
+containers, network, volumes and (on OrbStack) its `*.local` domains never collide with the main
+project or other worktrees.
+
+- `task worktrees:create NAME=my-feature` — create a worktree (new branch `my-feature`) in a
+  sibling directory `../[[ .ProjectShortName | toKebabCase ]]-worktrees/my-feature`, generate an
+  isolated `.env`, and bring its stack up. Pass `BRANCH=existing-branch` to check out an existing
+  branch instead. On OrbStack the app is served at `https://[[ .ProjectShortName | toKebabCase ]]-my-feature.local`;
+  without OrbStack the task prints the unique host ports it assigned.
+- `task worktrees:list` — list all worktrees.
+- `task worktrees:delete NAME=my-feature` — tear down the worktree's containers/volumes and remove
+  its directory (the git branch is kept; delete it with `git branch -d my-feature`).
+
 #### Using Clockwork to debug the application
 
 Checkout <https://[[ .ProjectShortName | toKebabCase ]].local/clockwork> to see the [clockwork](https://underground.works/clockwork/) dashboard.

--- a/template/Taskfile.dist.yml
+++ b/template/Taskfile.dist.yml
@@ -24,6 +24,7 @@ includes:
   setup: .taskfiles/Taskfile.setup.yml
   md: .taskfiles/Taskfile.md.yml
   cleanup: .taskfiles/Taskfile.cleanup.yml
+  worktrees: .taskfiles/Taskfile.worktrees.yml
 
 tasks:
 

--- a/template/compose.yml
+++ b/template/compose.yml
@@ -54,13 +54,13 @@ services:
     environment:
       CGI_HOST: "php.${COMPOSE_PROJECT_NAME}_default"
     labels:
-      - dev.orbstack.domains=[[ .ProjectShortName | toKebabCase ]].local
+      - dev.orbstack.domains=${COMPOSE_PROJECT_NAME:-[[ .ProjectShortName | toKebabCase ]]}.local
       - dev.orbstack.http-port=80
 [[- if .AddE2E ]]
     networks:
       default:
         aliases:
-          - [[ .ProjectShortName | toKebabCase ]].local
+          - ${COMPOSE_PROJECT_NAME:-[[ .ProjectShortName | toKebabCase ]]}.local
 [[- end ]]
 
 [[- if eq .Database "postgres" ]]
@@ -72,7 +72,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     labels:
-      - dev.orbstack.domains=[[ .DbOrbStackDomain ]]
+      - dev.orbstack.domains=db.${COMPOSE_PROJECT_NAME:-[[ .ProjectShortName | toKebabCase ]]}.local
 [[- else if eq .Database "mysql" ]]
 
   mysql:
@@ -83,7 +83,7 @@ services:
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     labels:
-      - dev.orbstack.domains=[[ .DbOrbStackDomain ]]
+      - dev.orbstack.domains=db.${COMPOSE_PROJECT_NAME:-[[ .ProjectShortName | toKebabCase ]]}.local
 [[- else ]]
 
   mariadb:
@@ -94,18 +94,18 @@ services:
       MARIADB_USER: ${MARIADB_USER}
       MARIADB_PASSWORD: ${MARIADB_PASSWORD}
     labels:
-      - dev.orbstack.domains=[[ .DbOrbStackDomain ]]
+      - dev.orbstack.domains=db.${COMPOSE_PROJECT_NAME:-[[ .ProjectShortName | toKebabCase ]]}.local
 [[- end ]]
 
   redis:
     image: redis:7.4.9-bookworm
     labels:
-      - dev.orbstack.domains=redis.[[ .ProjectShortName | toKebabCase ]].local
+      - dev.orbstack.domains=redis.${COMPOSE_PROJECT_NAME:-[[ .ProjectShortName | toKebabCase ]]}.local
 
   mailpit:
     image: axllent/mailpit:v1.30.2
     labels:
-      - dev.orbstack.domains=mail.[[ .ProjectShortName | toKebabCase ]].local
+      - dev.orbstack.domains=mail.${COMPOSE_PROJECT_NAME:-[[ .ProjectShortName | toKebabCase ]]}.local
       - dev.orbstack.http-port=8025
 
   markdown-linter:
@@ -120,5 +120,5 @@ services:
     depends_on:
       - nginx
     environment:
-      BASE_URL: http://[[ .ProjectShortName | toKebabCase ]].local
+      BASE_URL: http://${COMPOSE_PROJECT_NAME:-[[ .ProjectShortName | toKebabCase ]]}.local
 [[- end ]]


### PR DESCRIPTION
## What

Adds git-worktree support to the scaffolded project, so a developer can check out and **run multiple branches at the same time** — each with its own containers, volumes, dependencies (`vendor/`, `node_modules/`) and domains/ports.

The whole thing keys off `COMPOSE_PROJECT_NAME`: each worktree gets a unique one (`<project>-<slug>`), which isolates its containers, network, volumes and — after a small refactor — its OrbStack `*.local` domains.

## Why

`.env`, `vendor`, `node_modules` and `.task` are already gitignored, so every worktree gets fresh copies for free. The only blockers to running stacks in parallel were name/domain/port collisions:

- **OrbStack domains** in `compose.yml` were hardcoded (`acme.local`, `mail.acme.local`, …).
- **Host ports** in `compose.ports.yml` were fixed (`8080/5432|3306/6379/8025`) — only relevant without OrbStack.

## Changes

- **New `template/.taskfiles/Taskfile.worktrees.yml`** with three tasks:
  - `worktrees:list` (alias `ls`) — `git worktree list`.
  - `worktrees:create NAME=<name>` — adds a worktree at the sibling dir `../<project>-worktrees/<slug>`, generates an isolated `.env` (unique `COMPOSE_PROJECT_NAME`, OrbStack domain or — without OrbStack — unique host ports), then runs `task up`. Accepts `BRANCH=<existing-branch>` to check out an existing branch.
  - `worktrees:delete NAME=<name>` (aliases `remove`/`rm`) — runs `task down` then `git worktree remove --force` + `git worktree prune`, behind a confirmation prompt.
- **`template/compose.yml`** — the OrbStack domain labels (nginx, db, redis, mailpit, e2e alias/`BASE_URL`) now derive from `${COMPOSE_PROJECT_NAME:-<default>}`. The default equals the previous hardcoded value, so the **main project is byte-for-byte unchanged**.
- **`template/Taskfile.dist.yml`** — registers the new include.
- **`template/README.md`** — documents the workflow.

## Implementation notes

- **Domain parity:** `COMPOSE_PROJECT_NAME`'s default already equals the project short-name used in every domain label, so deriving labels from it changes nothing for the main stack (`docker compose config` confirmed identical output).
- **Avoiding the `task up` clobber:** `task up` runs `setup:env-file:local` which does `cp .env.example .env`. The create task seeds that env file **before** patching `.env`, recording Task's checksum so the subsequent `task up` treats it as up-to-date and does not overwrite the patched `COMPOSE_PROJECT_NAME`.
- **Slug guard:** both tasks have a precondition that fails fast if `NAME` slugifies to empty (e.g. `NAME=///`) — important for `delete`, where an empty slug would otherwise target the worktrees root.

## Caveats

- A worktree requires the project to have at least one commit (standard for `git worktree`).
- If `.env.example` later changes (e.g. a project update), a subsequent `task up` inside a worktree re-templates `.env` and resets `COMPOSE_PROJECT_NAME` — documented in the task `summary` and README.
- Without OrbStack, unique host ports are assigned via a deterministic slug-based offset; the task prints them and warns to verify no collisions.

## Testing

Verified end-to-end against a fresh `specs use --use-defaults` scaffold (PostgreSQL, OrbStack):

- `worktrees:create` brings up an isolated stack; `acme.local` **and** `acme-test-feature.local` both served `200` simultaneously, each with its own `acme-*` / `acme-test-feature-*` containers.
- Re-running `task up` in the worktree kept the patched `COMPOSE_PROJECT_NAME` (clobber regression).
- `worktrees:delete` tore down only the worktree's containers/volumes/network and removed the dir, leaving the main project running.
- Empty-slug precondition rejected `NAME=///` for both `create` and `delete` without touching any worktree.
