### PR TITLE
Updates

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -43,8 +43,8 @@ computed:
   DbPassword: password
 
   Php85DockerTag: "0.5.6" # Latest version: https://github.com/specsnl/php85/releases/latest
-  Php84DockerTag: "1.5.6" # Latest version: https://github.com/specsnl/php84/releases/latest
-  Php83DockerTag: "1.8.6" # Latest version: https://github.com/specsnl/php83/releases/latest
+  Php84DockerTag: "1.5.7" # Latest version: https://github.com/specsnl/php84/releases/latest
+  Php83DockerTag: "1.8.7" # Latest version: https://github.com/specsnl/php83/releases/latest
   PhpDockerTag: >-
     [[ eq .PhpVersion "8.4" | ternary .Php84DockerTag (eq .PhpVersion "8.3" | ternary .Php83DockerTag .Php85DockerTag) ]]
 

--- a/project.yml
+++ b/project.yml
@@ -42,7 +42,7 @@ computed:
     [[ .ProjectShortName | toSnakeCase ]]
   DbPassword: password
 
-  Php85DockerTag: "0.5.6" # Latest version: https://github.com/specsnl/php85/releases/latest
+  Php85DockerTag: "0.5.7" # Latest version: https://github.com/specsnl/php85/releases/latest
   Php84DockerTag: "1.5.7" # Latest version: https://github.com/specsnl/php84/releases/latest
   Php83DockerTag: "1.8.7" # Latest version: https://github.com/specsnl/php83/releases/latest
   PhpDockerTag: >-

--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -36,7 +36,9 @@ updates:
         patterns:
           - "specsnl/github-actions*"
   - package-ecosystem: docker
-    directory: /nginx
+    directories:
+      - /php
+      - /nginx
     schedule:
       interval: weekly
     ignore:
@@ -45,10 +47,7 @@ updates:
     labels:
       - dependencies
       - docker
-  - package-ecosystem: docker
-    directory: /php
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-      - docker
+    groups:
+      specsnl-php-images:
+        patterns:
+          - "specsnl/php*"

--- a/template/.taskfiles/Taskfile.worktrees.yml
+++ b/template/.taskfiles/Taskfile.worktrees.yml
@@ -70,12 +70,12 @@ tasks:
       # 3. Unique project name -> unique containers, network, volumes and domains.
       - |
         sed -e 's#^COMPOSE_PROJECT_NAME=.*#COMPOSE_PROJECT_NAME="{{ .PROJECT }}"#' \
-          "{{ .WT_PATH }}/.env" > "{{ .WT_PATH }}/.env.tmp" && mv "{{ .WT_PATH }}/.env.tmp" "{{ .WT_PATH }}/.env"
+          "{{ .WT_PATH }}/.env" > "{{ .WT_PATH }}/.env.tmp" && mv -f "{{ .WT_PATH }}/.env.tmp" "{{ .WT_PATH }}/.env"
       # 4a. OrbStack: unique *.local domain, no host ports needed.
       - if: '[ "{{ .ORBSTACK_ENABLED }}" = "1" ]'
         cmd: |
           sed -e 's#^APP_URL=.*#APP_URL=https://{{ .PROJECT }}.local#' \
-            "{{ .WT_PATH }}/.env" > "{{ .WT_PATH }}/.env.tmp" && mv "{{ .WT_PATH }}/.env.tmp" "{{ .WT_PATH }}/.env"
+            "{{ .WT_PATH }}/.env" > "{{ .WT_PATH }}/.env.tmp" && mv -f "{{ .WT_PATH }}/.env.tmp" "{{ .WT_PATH }}/.env"
       # 4b. No OrbStack: assign unique host ports (deterministic offset from the slug).
       - if: '[ "{{ .ORBSTACK_ENABLED }}" != "1" ]'
         cmd: |
@@ -89,7 +89,7 @@ tasks:
               -e "s#^DOCKER_REDIS_PORT=.*#DOCKER_REDIS_PORT=${REDIS_PORT}#" \
               -e "s#^DOCKER_MAILPIT_PORT=.*#DOCKER_MAILPIT_PORT=${MAILPIT_PORT}#" \
               -e "s#^APP_URL=.*#APP_URL=http://localhost:${NGINX_PORT}#" \
-            "{{ .WT_PATH }}/.env" > "{{ .WT_PATH }}/.env.tmp" && mv "{{ .WT_PATH }}/.env.tmp" "{{ .WT_PATH }}/.env"
+            "{{ .WT_PATH }}/.env" > "{{ .WT_PATH }}/.env.tmp" && mv -f "{{ .WT_PATH }}/.env.tmp" "{{ .WT_PATH }}/.env"
           echo "Assigned host ports -> nginx:${NGINX_PORT} db:${DB_PORT} redis:${REDIS_PORT} mailpit:${MAILPIT_PORT}"
           echo "Verify these do not collide with other running worktrees."
       # 5. Bring the worktree's stack up.

--- a/template/.taskfiles/Taskfile.worktrees.yml
+++ b/template/.taskfiles/Taskfile.worktrees.yml
@@ -103,6 +103,8 @@ tasks:
         [ "{{ .ORBSTACK_ENABLED }}" = "1" ] && echo "  url:     https://{{ .PROJECT }}.local"
         echo ""
         echo "Open it with: cd {{ .WT_PATH }}"
+      - if: test -n "$VISUAL"
+        cmd: $VISUAL {{ .WT_PATH }}
 
   delete:
     desc: Tear down a worktree's containers and remove the worktree

--- a/template/[[`.gitignore`]]
+++ b/template/[[`.gitignore`]]
@@ -53,3 +53,4 @@ _ide_helper.php
 # Agents
 CLAUDE.md
 AGENTS.md
+/.playwright-mcp

--- a/template/compose.mounts.yml
+++ b/template/compose.mounts.yml
@@ -1,5 +1,5 @@
 volumes:
-  [[ .ProjectShortName |toSnakeCase ]]_cache:
+  cache:
   [[ eq .Database "postgres" | ternary "postgres_data:" (eq .Database "mysql" | ternary "mysql_data:" "mariadb_data:") ]]
 
 services:
@@ -13,7 +13,7 @@ services:
         mkdir -p /cache/node
         chown -R ${FIXUID:-1000}:${FIXGID:-1000} /cache
     volumes:
-      - [[ .ProjectShortName | toSnakeCase ]]_cache:/cache
+      - cache:/cache
 
   php-exec:
     depends_on:
@@ -21,7 +21,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./:/var/www/
-      - [[ .ProjectShortName | toSnakeCase ]]_cache:/cache
+      - cache:/cache
       - ./auth.json:/config/composer/auth.json:ro
 
   php:
@@ -30,7 +30,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./:/var/www/
-      - [[ .ProjectShortName | toSnakeCase ]]_cache:/cache
+      - cache:/cache
       - ./auth.json:/config/composer/auth.json:ro
 
   worker:
@@ -39,7 +39,7 @@ services:
         condition: service_completed_successfully
     volumes:
       - ./:/var/www/
-      - [[ .ProjectShortName | toSnakeCase ]]_cache:/cache
+      - cache:/cache
       - ./auth.json:/config/composer/auth.json:ro
 
   nginx:
@@ -77,5 +77,5 @@ services:
   e2e-playwright:
     volumes:
       - ./:/var/www/
-      - [[ .ProjectShortName | toSnakeCase ]]_cache:/cache
+      - cache:/cache
 [[- end ]]


### PR DESCRIPTION
## Summary

A batch of maintenance updates to the project template:

- **Dependabot**: merge the two `docker` entries (`/php`, `/nginx`) into one using the multi-directory `directories:` key, and add a `specsnl-php-images` group matching `specsnl/php*` so all specsnl php image bumps land in a single PR across both directories. The existing `alpine` semver-major/minor ignore is preserved, so nginx/alpine base images still get their own PRs.
- **PHP images**: bump the templated PHP image versions.
- **Worktrees Taskfile**: prevent moving out of the current directory when running in non-interactive mode.
- **.gitignore**: add `.playwright-mcp`.
