### PR TITLE
Updated PR title check

### DIFF
--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     labels:
       - dependencies
       - php
+    commit-message:
+      prefix: build
+      include: scope
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -19,6 +22,9 @@ updates:
     labels:
       - dependencies
       - npm
+    commit-message:
+      prefix: build
+      include: scope
     groups:
       vite:
         patterns:
@@ -31,6 +37,9 @@ updates:
     labels:
       - dependencies
       - github-actions
+    commit-message:
+      prefix: build
+      include: scope
     groups:
       specsnl-actions:
         patterns:
@@ -47,6 +56,9 @@ updates:
     labels:
       - dependencies
       - docker
+    commit-message:
+      prefix: build
+      include: scope
     groups:
       specsnl-php-images:
         patterns:

--- a/template/.github/pr-title-checker-config.json
+++ b/template/.github/pr-title-checker-config.json
@@ -1,9 +1,0 @@
-{
-    "CHECKS": {
-        "regexp": "^[[ .IssuePrefix ]]-\\d{0,6}:[ \t]+[^\\s]{1}.*$"
-    },
-    "MESSAGES": {
-        "success": "All OK",
-        "failure": "Please add [[ .IssuePrefix ]]-XXX to your PR title where XXX is the issue number"
-    }
-}

--- a/template/.github/workflows/pr-title-checker.yml
+++ b/template/.github/workflows/pr-title-checker.yml
@@ -6,17 +6,22 @@ on:
       - reopened
       - edited
       - synchronize
-      - labeled
-      - unlabeled
+
+permissions:
+  pull-requests: read
 
 jobs:
   check-pr-title:
     name: Check PR Title
     runs-on: ubuntu-24.04
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - name: Checking PR title
-        uses: thehanimo/pr-title-checker@v1.4.3
-        with:
+        uses: amannn/action-semantic-pull-request@v6
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          configuration_path: .github/pr-title-checker-config.json
+        with:
+          requireScope: true
+          scopes: |
+            [[ .IssuePrefix ]]-\d{1,6}
+            deps
+            deps-dev


### PR DESCRIPTION
## What & why

Replaces the PR-title check action `thehanimo/pr-title-checker` with `amannn/action-semantic-pull-request` and moves the template from a prefix convention to **Conventional Commits**:

- Before: `ACME-1337: My commit message`
- After: `feat(ACME-1337): My commit message`

The issue reference (`[[ .IssuePrefix ]]` → `ACME`) now lives in the Conventional Commit **scope**.

## Changes

- **`template/.github/workflows/pr-title-checker.yml`** — rewritten to use `amannn/action-semantic-pull-request@v6`:
  - `requireScope: true` with `scopes:` = `[[ .IssuePrefix ]]-\d{1,6}`, plus `deps` / `deps-dev` (for Dependabot).
  - Commit `type` left at the action's default Conventional types (`feat`, `fix`, `build`, …).
  - `GITHUB_TOKEN` passed via `env:` (this action reads it from the environment).
  - Added `permissions: pull-requests: read` (least-privilege).
  - Events: `opened, reopened, edited, synchronize`. `synchronize` is required because **Check PR Title** is a required status check (`rulesets/Main.json`) — it must re-run on each new commit or it stays stale on the new head SHA. Dropped `labeled` / `unlabeled` (only used by the old label-based bypass).
  - Removed the `if: dependabot[bot]` skip — Dependabot PRs are now validated like any other.
- **`template/.github/dependabot.yml`** — added `commit-message: { prefix: build, include: scope }` to all four ecosystems (composer, npm, github-actions, docker) so Dependabot emits deterministic Conventional titles (`build(deps): …` / `build(deps-dev): …`) that pass the check. Without this, Dependabot only auto-detects the style from commit history, which is unreliable for freshly generated repos.
- **`template/.github/pr-title-checker-config.json`** — deleted; `amannn` is configured entirely via workflow `with:` inputs, so the JSON config is obsolete.

## Notes

- `\d{1,6}` mirrors the old `{0,6}` upper bound (now requires at least one digit). Widen to `\d+` if issue numbers can exceed 6 digits.